### PR TITLE
CockroachDB Hibernate dialect

### DIFF
--- a/roach-data-jpa/pom.xml
+++ b/roach-data-jpa/pom.xml
@@ -36,6 +36,11 @@
             <artifactId>spring-boot-starter-data-jpa</artifactId>
         </dependency>
         <dependency>
+            <groupId>org.hibernate</groupId>
+            <artifactId>hibernate-core</artifactId>
+            <version>5.4.19.Final</version>
+        </dependency>
+        <dependency>
             <groupId>org.liquibase</groupId>
             <artifactId>liquibase-core</artifactId>
             <scope>runtime</scope>

--- a/roach-data-jpa/src/main/resources/application.yml
+++ b/roach-data-jpa/src/main/resources/application.yml
@@ -25,3 +25,6 @@ spring:
 
   jpa:
     open-in-view: false
+    properties:
+      hibernate:
+        dialect: org.hibernate.dialect.CockroachDB201Dialect


### PR DESCRIPTION
Some updates to the JPA example following https://in.relation.to/2020/07/27/hibernate-orm-5419-final-release/

- Updated POM to pull latest Hibernate version. Versions before 5.4.19 do not support CRDB dialect.
- Updated properties file to use CockroachDB Hibernate dialect.